### PR TITLE
v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ keywords = ["vm","lisp","languages"]
 [dependencies]
 parser-combinators = "~0.2.6"
 log = "0.3.1"
-seax_svm = "^0.2.2"
+seax_svm = "^0.2.6"

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -323,7 +323,16 @@ impl ASTNode for SExprNode {
                             }
                             Ok(result)
                         }).and_then(|mut result: Vec<SVMCell> | {
-
+                            body_exp.compile(&sym)
+                                .map(|mut x| { x.push(InstCell(RET)); x })
+                                .map(|code | {
+                                    result.push_all(&[
+                                        InstCell(LDF),
+                                        ListCell(box List::from_iter(code)),
+                                        InstCell(AP)
+                                    ]);
+                                    result
+                                })
                             let mut body_code = Vec::new();
                             body_code.push_all(&try!(body_exp.compile(&sym)));
                             body_code.push(InstCell(RET));

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -333,7 +333,7 @@ impl ASTNode for SExprNode {
                                     ]);
                                     result
                                 })
-                    },
+                    }),
                     _ => Err(format!("[error]: malformed let expression:\n{:?}",self))
                 },
                 _ => { // TODO: this is basically a duplicate of the general case

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -18,12 +18,13 @@ use std::hash::Hash;
 #[cfg(test)]
 mod tests;
 
+pub type Index = (u64, u64);
 /// The symbol table for bound names is represented as a
 /// `ForkTable` mapping `&str` (names) to `(uint,uint)` tuples,
 /// representing the location in the `$e` stack storing the value
 /// bound to that name.
 #[stable(feature = "forktable", since = "0.0.6")]
-pub type SymTable<'a> = ForkTable<'a, &'a str, (usize,usize)>;
+pub type SymTable<'a> = ForkTable<'a, &'a str, Index>;
 
 /// A `CompileResult` is either `Ok(SVMCell)` or `Err(&str)`
 #[stable(feature = "compile", since = "0.0.3")]
@@ -38,13 +39,13 @@ pub trait Scope<K> where K: Eq + Hash {
     ///
     /// Returnsthe indices for that name in the SVM environment.
     #[stable(feature = "compile",since = "0.1.0")]
-    fn bind(&mut self, name: K, lvl: usize) -> (usize,usize);
+    fn bind(&mut self, name: K, lvl: u64) -> Index;
     /// Look up a name against a scope.
     ///
     /// Returns the indices for that name in the SVM environment,
     /// or None if that name is unbound.
     #[stable(feature = "compile",since = "0.1.0")]
-    fn lookup(&self, name: &K)              -> Option<(usize,usize)>;
+    fn lookup(&self, name: &K)            -> Option<Index>;
 }
 
 /// Trait for AST nodes.
@@ -441,7 +442,7 @@ impl SExprNode {
     /// in the top level of the closure with the lowest level of the stack at
     /// evaluation time.
     #[stable(feature = "compile",since = "0.1.0")]
-    fn depth(&self)     -> usize {
+    fn depth(&self)     -> u64 {
         self.operands.iter().fold(
             match *self.operator {
                 SExpr(ref node) => node.depth(),
@@ -600,7 +601,7 @@ impl ASTNode for NameNode {
 #[stable(feature = "ast", since = "0.0.2")]
 pub struct IntNode {
     #[stable(feature = "ast", since = "0.0.2")]
-    pub value: isize
+    pub value: i64
 }
 
 impl ASTNode for NumNode {
@@ -644,7 +645,7 @@ impl ASTNode for NumNode {
 #[stable(feature = "ast", since = "0.0.2")]
 pub struct UIntNode {
     #[stable(feature = "ast", since = "0.0.2")]
-    pub value: usize
+    pub value: u64
 }
 
 /// AST node for a floating-point constant

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -333,19 +333,6 @@ impl ASTNode for SExprNode {
                                     ]);
                                     result
                                 })
-                            let mut body_code = Vec::new();
-                            body_code.push_all(&try!(body_exp.compile(&sym)));
-                            body_code.push(InstCell(RET));
-
-                            result.push_all(&[
-                                InstCell(LDF),
-                                ListCell(box List::from_iter(body_code)),
-                                InstCell(AP)
-                            ]);
-
-                            Ok(result)
-
-                        })
                     },
                     _ => Err(format!("[error]: malformed let expression:\n{:?}",self))
                 },

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -333,7 +333,8 @@ impl ASTNode for SExprNode {
                                     ]);
                                     result
                                 })
-                    }),
+                        })
+                    },
                     _ => Err(format!("[error]: malformed let expression:\n{:?}",self))
                 },
                 _ => { // TODO: this is basically a duplicate of the general case

--- a/src/ast/tests.rs
+++ b/src/ast/tests.rs
@@ -13,8 +13,8 @@ fn test_compile_add() {
     let ast = SExprNode {
         operator: box Name(NameNode { name: "+".to_string() }),
         operands: vec![
-            NumConst(IntConst(IntNode{ value: 1isize })),
-            NumConst(IntConst(IntNode{ value: 2isize }))
+            NumConst(IntConst(IntNode{ value: 1 })),
+            NumConst(IntConst(IntNode{ value: 2 }))
         ]
     };
     assert_eq!(
@@ -32,9 +32,9 @@ fn test_compile_sub() {
     let ast = SExprNode {
         operator: box Name(NameNode { name: "-".to_string() }),
         operands: vec![
-            NumConst(UIntConst(UIntNode{ value: 9usize })),
-            NumConst(UIntConst(UIntNode{ value: 9usize })),
-            NumConst(UIntConst(UIntNode{ value: 9usize }))
+            NumConst(UIntConst(UIntNode{ value: 9 })),
+            NumConst(UIntConst(UIntNode{ value: 9 })),
+            NumConst(UIntConst(UIntNode{ value: 9 }))
         ]
     };
     assert_eq!(
@@ -54,21 +54,21 @@ fn test_compile_div() {
     let ast = SExprNode {
         operator: box Name(NameNode { name: "/".to_string() }),
         operands: vec![
-            NumConst(IntConst(IntNode{ value: 1isize })),
-            NumConst(IntConst(IntNode{ value: 2isize })),
-            NumConst(IntConst(IntNode{ value: 3isize })),
-            NumConst(IntConst(IntNode{ value: 4isize }))
+            NumConst(IntConst(IntNode{ value: 1 })),
+            NumConst(IntConst(IntNode{ value: 2 })),
+            NumConst(IntConst(IntNode{ value: 3 })),
+            NumConst(IntConst(IntNode{ value: 4 }))
         ]
     };
     assert_eq!(
         ast.compile(&SymTable::new()),
         Ok(vec![
-            InstCell(LDC), AtomCell(SInt(4isize)),
-            InstCell(LDC), AtomCell(SInt(3isize)),
+            InstCell(LDC), AtomCell(SInt(4)),
+            InstCell(LDC), AtomCell(SInt(3)),
             InstCell(DIV),
-            InstCell(LDC), AtomCell(SInt(2isize)),
+            InstCell(LDC), AtomCell(SInt(2)),
             InstCell(DIV),
-            InstCell(LDC), AtomCell(SInt(1isize)),
+            InstCell(LDC), AtomCell(SInt(1)),
             InstCell(DIV)
 
         ])
@@ -105,13 +105,13 @@ fn test_compile_nested_sexpr() {
     let ast = SExprNode {
         operator: box Name(NameNode { name: "+".to_string() }),
         operands: vec![
-            NumConst(IntConst(IntNode{ value: 4isize })),
+            NumConst(IntConst(IntNode{ value: 4 })),
             SExpr(SExprNode {
                 operator: box Name(NameNode { name: "-".to_string() }),
                 operands: vec![
-                    NumConst(IntConst(IntNode{ value: 1isize })),
-                    NumConst(IntConst(IntNode{ value: 2isize })),
-                    NumConst(IntConst(IntNode{ value: 3isize }))
+                    NumConst(IntConst(IntNode{ value: 1 })),
+                    NumConst(IntConst(IntNode{ value: 2 })),
+                    NumConst(IntConst(IntNode{ value: 3 }))
                 ]
             })
         ]
@@ -136,13 +136,13 @@ fn test_compile_gte() {
         operator: box Name(NameNode { name: ">=".to_string() }),
         operands: vec![
             NumConst(FloatConst(FloatNode{ value: 1f64 })),
-            NumConst(IntConst(IntNode{ value: 2isize })),
+            NumConst(IntConst(IntNode{ value: 2 })),
         ]
     };
     assert_eq!(
         ast.compile(&SymTable::new()),
         Ok(vec![
-            InstCell(LDC), AtomCell(SInt(2isize)),
+            InstCell(LDC), AtomCell(SInt(2)),
             InstCell(LDC), AtomCell(Float(1f64)),
             InstCell(GTE)
         ])
@@ -154,15 +154,15 @@ fn test_compile_lte() {
     let ast = SExprNode {
         operator: box Name(NameNode { name: "<=".to_string() }),
         operands: vec![
-            NumConst(UIntConst(UIntNode{ value: 3usize })),
-            NumConst(IntConst(IntNode{ value: 2isize })),
+            NumConst(UIntConst(UIntNode{ value: 3 })),
+            NumConst(IntConst(IntNode{ value: 2 })),
         ]
     };
     assert_eq!(
         ast.compile(&SymTable::new()),
         Ok(vec![
-            InstCell(LDC), AtomCell(SInt(2isize)),
-            InstCell(LDC), AtomCell(UInt(3usize)),
+            InstCell(LDC), AtomCell(SInt(2)),
+            InstCell(LDC), AtomCell(UInt(3)),
             InstCell(LTE)
         ])
     )
@@ -185,4 +185,3 @@ fn test_compile_string() {
             ))])
         )
 }
-

--- a/src/forktab.rs
+++ b/src/forktab.rs
@@ -24,7 +24,7 @@ use super::ast::Scope;
 /// reference implementation written by Hawk Weisman for the Decaf
 /// compiler, which is available [here](https://github.com/hawkw/decaf/blob/master/src/main/scala/com/meteorcode/common/ForkTable.scala).
 #[derive(Debug)]
-#[unstable(feature = "forktable")]
+#[stable(feature = "forktable", since = "0.2.6")]
 pub struct ForkTable<'a, K, V>
     where K: 'a + Eq + Hash,
           V: 'a
@@ -64,19 +64,19 @@ impl<'a, K, V> ForkTable<'a, K, V>
     /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut table: ForkTable<isize,&str> = ForkTable::new();
-    /// assert_eq!(table.get(&1isize), None);
-    /// table.insert(1isize, "One");
-    /// assert_eq!(table.get(&1isize), Some(&"One"));
-    /// assert_eq!(table.get(&2isize), None);
+    /// assert_eq!(table.get(&1), None);
+    /// table.insert(1, "One");
+    /// assert_eq!(table.get(&1), Some(&"One"));
+    /// assert_eq!(table.get(&2), None);
     /// ```
     /// ```
     /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut level_1: ForkTable<isize,&str> = ForkTable::new();
-    /// level_1.insert(1isize, "One");
+    /// level_1.insert(1, "One");
     ///
     /// let mut level_2: ForkTable<isize,&str> = level_1.fork();
-    /// assert_eq!(level_2.get(&1isize), Some(&"One"));
+    /// assert_eq!(level_2.get(&1), Some(&"One"));
     /// ```
     #[stable(feature = "forktable", since = "0.2.6")]
     pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<&V>
@@ -96,9 +96,12 @@ impl<'a, K, V> ForkTable<'a, K, V>
 
     /// Returns a mutable reference to the value corresponding to the key.
     ///
-    /// If the key is defined in this level of the table, or in any
-    /// of its' parents, a reference to the associated value will be
-    /// returned.
+    /// If the key is defined in this level of the table, a reference to the
+    /// associated value will be returned.
+    ///
+    /// Note that only keys defined in this level of the table can be accessed
+    /// as mutable. This is because otherwise it would be necessary for each
+    /// level of the table to hold a mutable reference to its parent.
     ///
     /// The key may be any borrowed form of the map's key type, but
     /// `Hash` and `Eq` on the borrowed form *must* match those for
@@ -119,21 +122,21 @@ impl<'a, K, V> ForkTable<'a, K, V>
     /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut table: ForkTable<isize,&str> = ForkTable::new();
-    /// assert_eq!(table.get_mut(&1isize), None);
+    /// assert_eq!(table.get_mut(&1), None);
     /// table.insert(1isize, "One");
-    /// assert_eq!(table.get_mut(&1isize), Some(&mut "One"));
-    /// assert_eq!(table.get_mut(&2isize), None);
+    /// assert_eq!(table.get_mut(&1), Some(&mut "One"));
+    /// assert_eq!(table.get_mut(&2), None);
     /// ```
     /// ```
     /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut level_1: ForkTable<isize,&str> = ForkTable::new();
-    /// level_1.insert(1isize, "One");
+    /// level_1.insert(1, "One");
     ///
     /// let mut level_2: ForkTable<isize,&str> = level_1.fork();
-    /// assert_eq!(level_2.get_mut(&1isize), None);
+    /// assert_eq!(level_2.get_mut(&1), None);
     /// ```
-    #[unstable(feature = "forktable")]
+    #[stable(feature = "forktable", since  = "0.2.6")]
     pub fn get_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<&mut V>
         where K: Borrow<Q>,
              Q: Hash + Eq
@@ -170,22 +173,22 @@ impl<'a, K, V> ForkTable<'a, K, V>
     /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut table: ForkTable<isize,&str> = ForkTable::new();
-    /// table.insert(1isize, "One");
+    /// table.insert(1, "One");
     ///
-    /// assert_eq!(table.remove(&1isize), Some("One"));
-    /// assert_eq!(table.contains_key(&1isize), false);
+    /// assert_eq!(table.remove(&1), Some("One"));
+    /// assert_eq!(table.contains_key(&1), false);
     /// ```
     /// ```
     /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut level_1: ForkTable<isize,&str> = ForkTable::new();
-    /// level_1.insert(1isize, "One");
-    /// assert_eq!(level_1.contains_key(&1isize), true);
+    /// level_1.insert(1, "One");
+    /// assert_eq!(level_1.contains_key(&1), true);
     ///
     /// let mut level_2: ForkTable<isize,&str> = level_1.fork();
-    /// assert_eq!(level_2.chain_contains_key(&1isize), true);
-    /// assert_eq!(level_2.remove(&1isize), None);
-    /// assert_eq!(level_2.chain_contains_key(&1isize), false);
+    /// assert_eq!(level_2.chain_contains_key(&1), true);
+    /// assert_eq!(level_2.remove(&1), None);
+    /// assert_eq!(level_2.chain_contains_key(&1), false);
     /// ```
     ///
     #[stable(feature = "forktable", since="0.2.6")]
@@ -230,9 +233,9 @@ impl<'a, K, V> ForkTable<'a, K, V>
     /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut table: ForkTable<isize,&str> = ForkTable::new();
-    /// assert_eq!(table.get(&1isize), None);
-    /// table.insert(1isize, "One");
-    /// assert_eq!(table.get(&1isize), Some(&"One"));
+    /// assert_eq!(table.get(&1), None);
+    /// table.insert(1, "One");
+    /// assert_eq!(table.get(&1), Some(&"One"));
     /// ```
     ///
     /// Overwriting the value associated with a key:
@@ -274,20 +277,20 @@ impl<'a, K, V> ForkTable<'a, K, V>
     /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut table: ForkTable<isize,&str> = ForkTable::new();
-    /// assert_eq!(table.contains_key(&1isize), false);
-    /// table.insert(1isize, "One");
-    /// assert_eq!(table.contains_key(&1isize), true);
+    /// assert_eq!(table.contains_key(&1), false);
+    /// table.insert(1, "One");
+    /// assert_eq!(table.contains_key(&1), true);
     /// ```
     /// ```
     /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut level_1: ForkTable<isize,&str> = ForkTable::new();
-    /// assert_eq!(level_1.contains_key(&1isize), false);
-    /// level_1.insert(1isize, "One");
-    /// assert_eq!(level_1.contains_key(&1isize), true);
+    /// assert_eq!(level_1.contains_key(&1), false);
+    /// level_1.insert(1, "One");
+    /// assert_eq!(level_1.contains_key(&1), true);
     ///
     /// let mut level_2: ForkTable<isize,&str> = level_1.fork();
-    /// assert_eq!(level_2.contains_key(&1isize), false);
+    /// assert_eq!(level_2.contains_key(&1), false);
     /// ```
     #[stable(feature = "forktable", since = "0.2.6")]
     pub fn contains_key<Q: ?Sized>(&self, key: &Q) -> bool
@@ -319,20 +322,20 @@ impl<'a, K, V> ForkTable<'a, K, V>
     /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut table: ForkTable<isize,&str> = ForkTable::new();
-    /// assert_eq!(table.chain_contains_key(&1isize), false);
-    /// table.insert(1isize, "One");
-    /// assert_eq!(table.chain_contains_key(&1isize), true);
+    /// assert_eq!(table.chain_contains_key(&1), false);
+    /// table.insert(1, "One");
+    /// assert_eq!(table.chain_contains_key(&1), true);
     /// ```
     /// ```
     /// # #![feature(forktable,scheme)]
     /// # use seax_scheme::ForkTable;
     /// let mut level_1: ForkTable<isize,&str> = ForkTable::new();
-    /// assert_eq!(level_1.chain_contains_key(&1isize), false);
-    /// level_1.insert(1isize, "One");
-    /// assert_eq!(level_1.chain_contains_key(&1isize), true);
+    /// assert_eq!(level_1.chain_contains_key(&1), false);
+    /// level_1.insert(1, "One");
+    /// assert_eq!(level_1.chain_contains_key(&1), true);
     ///
     /// let mut level_2: ForkTable<isize,&str> = level_1.fork();
-    /// assert_eq!(level_2.chain_contains_key(&1isize), true);
+    /// assert_eq!(level_2.chain_contains_key(&1), true);
     /// ```
     #[stable(feature = "forktable", since = "0.2.6")]
     pub fn chain_contains_key<Q:? Sized>(&self, key: &Q) -> bool

--- a/src/forktab.rs
+++ b/src/forktab.rs
@@ -24,7 +24,7 @@ use super::ast::Scope;
 /// reference implementation written by Hawk Weisman for the Decaf
 /// compiler, which is available [here](https://github.com/hawkw/decaf/blob/master/src/main/scala/com/meteorcode/common/ForkTable.scala).
 #[derive(Debug)]
-#[stable(feature = "forktable", since = "0.2.6")]
+#[stable(feature = "forktable", since = "0.2.2")]
 pub struct ForkTable<'a, K, V>
     where K: 'a + Eq + Hash,
           V: 'a
@@ -78,7 +78,7 @@ impl<'a, K, V> ForkTable<'a, K, V>
     /// let mut level_2: ForkTable<isize,&str> = level_1.fork();
     /// assert_eq!(level_2.get(&1), Some(&"One"));
     /// ```
-    #[stable(feature = "forktable", since = "0.2.6")]
+    #[stable(feature = "forktable", since = "0.2.2")]
     pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<&V>
         where K: Borrow<Q>,
               Q: Hash + Eq
@@ -136,7 +136,7 @@ impl<'a, K, V> ForkTable<'a, K, V>
     /// let mut level_2: ForkTable<isize,&str> = level_1.fork();
     /// assert_eq!(level_2.get_mut(&1), None);
     /// ```
-    #[stable(feature = "forktable", since  = "0.2.6")]
+    #[stable(feature = "forktable", since  = "0.2.2")]
     pub fn get_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<&mut V>
         where K: Borrow<Q>,
              Q: Hash + Eq
@@ -292,7 +292,7 @@ impl<'a, K, V> ForkTable<'a, K, V>
     /// let mut level_2: ForkTable<isize,&str> = level_1.fork();
     /// assert_eq!(level_2.contains_key(&1), false);
     /// ```
-    #[stable(feature = "forktable", since = "0.2.6")]
+    #[stable(feature = "forktable", since = "0.2.2")]
     pub fn contains_key<Q: ?Sized>(&self, key: &Q) -> bool
         where K: Borrow<Q>,
               Q: Hash + Eq
@@ -337,7 +337,7 @@ impl<'a, K, V> ForkTable<'a, K, V>
     /// let mut level_2: ForkTable<isize,&str> = level_1.fork();
     /// assert_eq!(level_2.chain_contains_key(&1), true);
     /// ```
-    #[stable(feature = "forktable", since = "0.2.6")]
+    #[stable(feature = "forktable", since = "0.2.2")]
     pub fn chain_contains_key<Q:? Sized>(&self, key: &Q) -> bool
         where K: Borrow<Q>,
               Q: Hash + Eq
@@ -493,7 +493,7 @@ impl<'a> Scope<&'a str> for ForkTable<'a, &'a str, (usize,usize)> {
     ///
     ///  + `Some(usize,usize)` if the name is bound in the symbol table
     ///  + `None` if the name is unbound
-    #[stable(feature = "compile",since = "0.2.6")]
+    #[stable(feature = "compile",since = "0.2.2")]
     fn lookup(&self, name: &&'a str)             -> Option<(usize,usize)> {
         self.get(name) // TODO: shouldn't usize be Copy?
             .map(|&( lvl, idx )| (lvl.clone(), idx.clone()) )

--- a/src/forktab.rs
+++ b/src/forktab.rs
@@ -5,7 +5,7 @@ use std::borrow::Borrow;
 use std::cmp::max;
 use std::ops;
 
-use super::ast::Scope;
+use super::ast::{Scope,Index};
 
 /// An associative map data structure for representing scopes.
 ///
@@ -459,7 +459,7 @@ impl<'a, 'b, K, Q: ?Sized, V> ops::IndexMut<&'b Q> for ForkTable<'a, K, V>
 /// representing the location in the `$e` stack storing the value
 /// bound to that name.
 #[stable(feature = "compile",since = "0.1.0")]
-impl<'a> Scope<&'a str> for ForkTable<'a, &'a str, (usize,usize)> {
+impl<'a> Scope<&'a str> for ForkTable<'a, &'a str, Index> {
     /// Bind a name to a scope.
     ///
     /// Returns the indices for that name in the SVM environment.
@@ -474,11 +474,11 @@ impl<'a> Scope<&'a str> for ForkTable<'a, &'a str, (usize,usize)> {
     /// A tuple containing the indexes for that name in the
     /// SVM environment (as `usize`).
     #[stable(feature = "compile",since = "0.1.0")]
-    fn bind(&mut self,name: &'a str, lvl: usize) -> (usize,usize) {
+    fn bind(&mut self,name: &'a str, lvl: u64) -> Index {
         let idx = self.values()
                       .fold(0, |a,i| max(a,i.1)) + 1;
         self.insert(name, (lvl,idx));
-        (self.level, idx)
+        (self.level as u64, idx)
     }
     /// Look up a name against a scope.
     ///
@@ -494,7 +494,7 @@ impl<'a> Scope<&'a str> for ForkTable<'a, &'a str, (usize,usize)> {
     ///  + `Some(usize,usize)` if the name is bound in the symbol table
     ///  + `None` if the name is unbound
     #[stable(feature = "compile",since = "0.2.2")]
-    fn lookup(&self, name: &&'a str)             -> Option<(usize,usize)> {
+    fn lookup(&self, name: &&'a str)            -> Option<Index> {
         self.get(name) // TODO: shouldn't usize be Copy?
             .map(|&( lvl, idx )| (lvl.clone(), idx.clone()) )
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -38,22 +38,22 @@ fn hex_scalar(input: State<&str>) -> ParseResult<String, &str> {
 #[unstable(feature="parser")]
 pub fn sint_const(input: State<&str>) -> ParseResult<NumNode, &str> {
 
-    fn hex_int(input: State<&str>) -> ParseResult<isize, &str> {
+    fn hex_int(input: State<&str>) -> ParseResult<i64, &str> {
         satisfy(|c| c == '#')
             .with(parser(hex_scalar)
-                    .map(|x| isize::from_str_radix(x.as_ref(), 16).unwrap()) )
+                    .map(|x| i64::from_str_radix(x.as_ref(), 16).unwrap()) )
             .parse_state(input)
     }
 
-    fn dec_int(input: State<&str>) -> ParseResult<isize, &str> {
+    fn dec_int(input: State<&str>) -> ParseResult<i64, &str> {
         optional(satisfy(|c| c == '#')
             .and(satisfy(|c| c == 'd' || c == 'D')))
             .with(many1::<String, _>(digit())
-                .map(|x| isize::from_str(x.as_ref()).unwrap() ))
+                .map(|x| i64::from_str(x.as_ref()).unwrap() ))
             .parse_state(input)
     }
 
-    fn signed(input: State<&str>) -> ParseResult<(Option<char>,isize), &str> {
+    fn signed(input: State<&str>) -> ParseResult<(Option<char>,i64), &str> {
         optional(satisfy(|c| c == '-'))
             .and(
                 try(parser(hex_int))
@@ -68,7 +68,7 @@ pub fn sint_const(input: State<&str>) -> ParseResult<NumNode, &str> {
                 let mut s = String::new();
                 s.push(sign);
                 s.push('1');
-                x.1 * isize::from_str(s.as_ref()).unwrap()
+                x.1 * i64::from_str(s.as_ref()).unwrap()
             } else {
                 x.1
             }
@@ -76,7 +76,7 @@ pub fn sint_const(input: State<&str>) -> ParseResult<NumNode, &str> {
         .skip(not_followed_by(satisfy(|c|
             c == 'u' || c == 'U' || c == '.' || c == 'f' || c == 'F')
         ))
-        .map(|x: isize| NumNode::IntConst(IntNode{value: x}))
+        .map(|x: i64| NumNode::IntConst(IntNode{value: x}))
         .parse_state(input)
 }
 
@@ -90,23 +90,23 @@ pub fn sint_const(input: State<&str>) -> ParseResult<NumNode, &str> {
 #[unstable(feature="parser")]
 pub fn uint_const(input: State<&str>) -> ParseResult<NumNode, &str> {
 
-    fn hex_uint(input: State<&str>) -> ParseResult<usize, &str> {
+    fn hex_uint(input: State<&str>) -> ParseResult<u64, &str> {
         satisfy(|c| c == '#')
             .with(parser(hex_scalar)
-                    .map(|x| usize::from_str_radix(x.as_ref(), 16).unwrap()) )
+                    .map(|x| u64::from_str_radix(x.as_ref(), 16).unwrap()) )
             .parse_state(input)
     }
 
-    fn dec_uint(input: State<&str>) -> ParseResult<usize, &str> {
+    fn dec_uint(input: State<&str>) -> ParseResult<u64, &str> {
         many1::<String, _>(digit())
-            .map(|x|usize::from_str(x.as_ref()).unwrap() )
+            .map(|x| u64::from_str(x.as_ref()).unwrap() )
             .parse_state(input)
     }
 
     try(parser(hex_uint))
         .or(parser(dec_uint))
         .skip(satisfy(|c| c == 'u' || c == 'U'))
-        .map(|x: usize| NumNode::UIntConst(UIntNode{value: x}))
+        .map(|x: u64| NumNode::UIntConst(UIntNode{value: x}))
         .parse_state(input)
 }
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -66,15 +66,15 @@ fn test_square_bracket_sexpr() {
 fn test_lex_sint_pos() {
     assert_eq!(
         parser(number).parse("1234"),
-        Ok((IntConst(IntNode { value: 1234isize }), ""))
+        Ok((IntConst(IntNode { value: 1234 }), ""))
         );
     assert_eq!(
         parser(number).parse("#d1234"),
-        Ok((IntConst(IntNode { value: 1234isize }), ""))
+        Ok((IntConst(IntNode { value: 1234 }), ""))
         );
     assert_eq!(
         parser(number).parse("#D1234"),
-        Ok((IntConst(IntNode { value: 1234isize }), ""))
+        Ok((IntConst(IntNode { value: 1234 }), ""))
         );
 }
 
@@ -82,7 +82,7 @@ fn test_lex_sint_pos() {
 fn test_lex_sint_neg() {
     assert_eq!(
         parser(number).parse("-1234"),
-        Ok((IntConst(IntNode { value: -1234isize }), ""))
+        Ok((IntConst(IntNode { value: -1234 }), ""))
         );
 }
 
@@ -90,11 +90,11 @@ fn test_lex_sint_neg() {
 fn test_lex_sint_hex() {
     assert_eq!(
         parser(number).parse("#x0ff"),
-        Ok((IntConst(IntNode { value: 0x0ffisize }), ""))
+        Ok((IntConst(IntNode { value: 0x0ff }), ""))
         );
     assert_eq!(
         parser(number).parse("#X0FF"),
-        Ok((IntConst(IntNode { value: 0x0ffisize }), ""))
+        Ok((IntConst(IntNode { value: 0x0ff }), ""))
         );
 }
 /* // Currently unsupported
@@ -114,11 +114,11 @@ fn test_parse_sint_bin_upper() {
 fn test_lex_uint() {
     assert_eq!(
         parser(number).parse("1234u"),
-        Ok((UIntConst(UIntNode { value: 1234usize }), ""))
+        Ok((UIntConst(UIntNode { value: 1234 }), ""))
         );
     assert_eq!(
         parser(number).parse("4321U"),
-        Ok((UIntConst(UIntNode { value: 4321usize }), ""))
+        Ok((UIntConst(UIntNode { value: 4321 }), ""))
         );
 }
 
@@ -126,11 +126,11 @@ fn test_lex_uint() {
 fn test_lex_uint_hex() {
     assert_eq!(
         parser(number).parse("#x0ffu"),
-        Ok((UIntConst(UIntNode { value: 0x0ffusize }), ""))
+        Ok((UIntConst(UIntNode { value: 0x0ff }), ""))
         );
     assert_eq!(
         parser(number).parse("#X0FFu"),
-        Ok((UIntConst(UIntNode { value: 0x0ffusize }), ""))
+        Ok((UIntConst(UIntNode { value: 0x0ff }), ""))
         );
 }
 


### PR DESCRIPTION
## Added:
- Indexing for `ForkTable`
- Stabilised unstable `ForkTable` API
## Fixed:
- Compatibility with Seax Virtual Machine 64-bit integers
- Some testing improvements
- Updated documentation
- Coding style improvements in compilation for `let`, `lambda`, and `if` expressions.
